### PR TITLE
Fixed a typo in the vvvvvv.bat

### DIFF
--- a/vvvvvv.bat
+++ b/vvvvvv.bat
@@ -1,3 +1,3 @@
 @echo off
-py3 vvvvv.py
+py3 vvvvvv.py
 pause


### PR DESCRIPTION
The command that runs the file, `py3 vvvvv.py` was misspelled and I corrected it to `vvvvvv.py` It was missing a `v` This prevented the bat file from starting the game.