### PR TITLE
imports pygame after installing

### DIFF
--- a/vvvvvv.py
+++ b/vvvvvv.py
@@ -4,6 +4,7 @@ try:
     from pygame.draw import line, rect
 except ImportError:
     os.system('py3 -m pip install pygame')  # Automatically install PyGame
+import pygame
 from spritesheet import Spritesheet   # Saved in another file since it's used elsewhere
 from palette import Palette
 


### PR DESCRIPTION
the main vvvvvv.py file checks to see whether or not you have pygame installed, installs it, then forgets to import it (original file might work just fine on other python 3 versions, am using 3.9.1)